### PR TITLE
kollector_multiple.sh: Calls to kollector.sh not adding "B" parameter properly

### DIFF
--- a/bin/kollector_multiple.sh
+++ b/bin/kollector_multiple.sh
@@ -123,16 +123,16 @@ then
 	then
 		if [ -z ${B+x} ]
 		then
-			kollector.sh -j$j -d$d -k$k -K$K -r$r -s$s -n$n -o$o -B$B ../$seed_symlink $pet1 $pet2
-		else
 			kollector.sh -j$j -d$d -k$k -K$K -r$r -s$s -n$n -o$o ../$seed_symlink $pet1 $pet2
+		else
+			kollector.sh -j$j -d$d -k$k -K$K -r$r -s$s -n$n -o$o -B$B ../$seed_symlink $pet1 $pet2
 		fi
 	else
 		if [ -z ${B+x} ]
 		then
-			kollector.sh -j$j -d$d -k$k -K$K -r$r -s$s -p$p -n$n -o$o -B$B ../$seed_symlink $pet1 $pet2
-		else
 			kollector.sh -j$j -d$d -k$k -K$K -r$r -s$s -p$p -n$n -o$o ../$seed_symlink $pet1 $pet2
+		else
+			kollector.sh -j$j -d$d -k$k -K$K -r$r -s$s -p$p -n$n -o$o -B$B ../$seed_symlink $pet1 $pet2
 		fi
 	fi
 	cut -f2 -d " " ${o}_hitlist.txt|sort|uniq > ${o}_succeedtranscripts.txt

--- a/bin/kollector_multiple.sh
+++ b/bin/kollector_multiple.sh
@@ -152,16 +152,16 @@ else
 	then
 		if [ -z ${B+x} ]
 		then
-			kollector.sh -j$j -d$d -k$k -K$K -r$r -s$s -n$n -o$o $seed_new $pet1 $pet2
+			kollector.sh -j$j -d$d -k$k -K$K -r$newr -s$s -n$n -o$o $seed_new $pet1 $pet2
 		else
-			kollector.sh -j$j -d$d -k$k -K$K -r$r -s$s -n$n -o$o -B$B $seed_new $pet1 $pet2
+			kollector.sh -j$j -d$d -k$k -K$K -r$newr -s$s -n$n -o$o -B$B $seed_new $pet1 $pet2
 		fi
 	else
 		if [ -z ${B+x} ]
 		then
-			kollector.sh -j$j -d$d -k$k -K$K -r$r -s$s -p$p -n$n -o$o $seed_new $pet1 $pet2
+			kollector.sh -j$j -d$d -k$k -K$K -r$newr -s$s -p$p -n$n -o$o $seed_new $pet1 $pet2
 		else
-			kollector.sh -j$j -d$d -k$k -K$K -r$r -s$s -p$p -n$n -o$o -B$B $seed_new $pet1 $pet2
+			kollector.sh -j$j -d$d -k$k -K$K -r$newr -s$s -p$p -n$n -o$o -B$B $seed_new $pet1 $pet2
 		fi
 	fi
 	cut -f2 -d " " ${o}_hitlist.txt|sort|uniq > ${o}_succeedtranscripts.txt

--- a/bin/kollector_multiple.sh
+++ b/bin/kollector_multiple.sh
@@ -152,16 +152,16 @@ else
 	then
 		if [ -z ${B+x} ]
 		then
-			kollector.sh -j$j -d$d -k$k -K$K -r$r -s$s -n$n -o$o -B$B $seed_new $pet1 $pet2
-		else
 			kollector.sh -j$j -d$d -k$k -K$K -r$r -s$s -n$n -o$o $seed_new $pet1 $pet2
+		else
+			kollector.sh -j$j -d$d -k$k -K$K -r$r -s$s -n$n -o$o -B$B $seed_new $pet1 $pet2
 		fi
 	else
 		if [ -z ${B+x} ]
 		then
-			kollector.sh -j$j -d$d -k$k -K$K -r$r -s$s -p$p -n$n -o$o -B$B $seed_new $pet1 $pet2
-		else
 			kollector.sh -j$j -d$d -k$k -K$K -r$r -s$s -p$p -n$n -o$o $seed_new $pet1 $pet2
+		else
+			kollector.sh -j$j -d$d -k$k -K$K -r$r -s$s -p$p -n$n -o$o -B$B $seed_new $pet1 $pet2
 		fi
 	fi
 	cut -f2 -d " " ${o}_hitlist.txt|sort|uniq > ${o}_succeedtranscripts.txt


### PR DESCRIPTION
In kollector_multiple.sh, the calls to kollector.sh were not including the "-B" parameter even when it was specified. It looks like the calls were just the opposite to how they should be.