### PR TITLE
Error in BioBloomCategorizer running kollector.sh

### DIFF
--- a/bin/kollector-recruit.mk
+++ b/bin/kollector-recruit.mk
@@ -60,4 +60,4 @@ $(name)_BBT.bf: $(seed).fai  $(pe1) $(pe2)
 		
 #filter PET reads with built BF
 $(name).recruited_pe.fastq: $(name)_BBT.bf $(pe1) $(pe2)
-	biobloomcategorizer -p $(name)_BBT -t $j -d -f $(name)_BBT.bf -s $s -e -i <(zcat -f -- $(pe1)) <(zcat -f -- $(pe2)) >> $@	
+	biobloomcategorizer -p $(name)_BBT -t $j -d $(name)_BBT -f $(name)_BBT.bf -s $s -e -i <(zcat -f -- $(pe1)) <(zcat -f -- $(pe2)) >> $@	


### PR DESCRIPTION
Execution stops and this message appears:

Usage of paired end mode:
BioBloomCategorizer [OPTION]... -f "[FILTER1]..." [FILEPAIR1] [FILEPAIR2]
or BioBloomCategorizer [OPTION]... -f "[FILTER1]..." [PAIREDBAMSAM]

biobloomcategorizer -h
[...]
-d, --stdout_filter=N  Outputs all matching reads to stdout for the specified
                         filter. N is the filter ID without file extension.
                         [...]