### PR TITLE
Mac os support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ brew install abyss
 
 To see an simple example for running Kollector please see the `Example` section below.
 
+#### MacOS Support
+Running Kollector on MacOS requires some additional dependencies.  In particular,
+it requires the GNU versions of `awk`, `du`, and `time`.
+
+Installing these dependencies can be done with homebrew:
+
+```{bash}
+brew install coreutils gawk gnu-time
+```
+
 ## Running Kollector
 
 Kollector consists of three bash scripts:

--- a/bin/kollector-recruit.mk
+++ b/bin/kollector-recruit.mk
@@ -56,8 +56,8 @@ endif
 
 # iteratively add PETs with paired matches to Bloom filter
 $(name)_BBT.bf: $(seed).fai  $(pe1) $(pe2)
-	biobloommaker -i -k $k -p $(name)_BBT -f $(max_fpr) -t $j -n $n -r $r $(if $(subtract),-s $(subtract))  $(seed) <(zcat -f -- $(pe1)) <(zcat -f -- $(pe2))
+	biobloommaker -i -k $k -p $(name)_BBT -f $(max_fpr) -t $j -n $n -r $r $(if $(subtract),-s $(subtract))  $(seed) <(zcat -f -- < $(pe1)) <(zcat -f -- < $(pe2))
 		
 #filter PET reads with built BF
 $(name).recruited_pe.fastq: $(name)_BBT.bf $(pe1) $(pe2)
-	biobloomcategorizer -p $(name)_BBT -t $j -d -f $(name)_BBT.bf -s $s -e -i <(zcat -f -- $(pe1)) <(zcat -f -- $(pe2)) >> $@	
+	biobloomcategorizer -p $(name)_BBT -t $j -d -f $(name)_BBT.bf -s $s -e -i <(zcat -f -- < $(pe1)) <(zcat -f -- < $(pe2)) >> $@	

--- a/test/Makefile
+++ b/test/Makefile
@@ -50,6 +50,7 @@ deps:
 	@echo $(brew_deps)
 
 install-deps:
+	brew tap brewsci/bio
 	brew install $(brew_deps)
 
 #Download genomic reads from NCBI

--- a/test/Makefile
+++ b/test/Makefile
@@ -38,6 +38,14 @@ curl: \
 
 brew_deps= samtools biobloomtools abyss gmap-gsnap bwa
 
+# check if not windows
+ifneq ($(OS),Windows_NT)
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+    brew_deps += gnu-time gawk coreutils
+  endif
+endif
+
 deps:
 	@echo $(brew_deps)
 


### PR DESCRIPTION
The current version of kollector relies on gnu-specific flags to core *nix programs resulting in errors when used on non-linux systems (e.g., issue #21).

I've changed `kollector.sh` to check for MacOS and update internal commands accordingly.  Additionally, `collector-recruit.mk` is updated to use a more robust `zcat` command that works across Mac and linux platforms.