### PR TITLE
kollector_multiple: fix setting $B when it should be unset unless specified

### DIFF
--- a/bin/kollector_multiple.sh
+++ b/bin/kollector_multiple.sh
@@ -46,7 +46,6 @@ set -eu -o pipefail
 #------------------------------------------------------------
 
 # default values for options
-B=0
 align=0
 evaluate=0
 j=1


### PR DESCRIPTION
The $B variable is set by default prior to argument parsing, and subsequent -z tests on the variable are always evaluated to true.
-B$B is then passed to kollector.sh, which in turn passes an invalid B=0 setting to abyss-pe.
Later in the execution chain, abyss-bloom-dbg is called with -b 0, which is recognized as an invalid setting, and the command fails with a "missing mandatory option `-b'" error.

The patch removes the $B variable assignment at the top of kollector_multiple.sh to fix this.