### PR TITLE
kollector.sh: use all assigned physical cores + hyperthreading for everything except MPI

### DIFF
--- a/bin/kollector.sh
+++ b/bin/kollector.sh
@@ -207,7 +207,7 @@ if [ -z ${B+x} ]
 then
 	time_command abyss-pe -C $abyss_dir v=-v k=$k name=$prefix np=$j  lib='pet' pet=$abyss_input long='longlib' longlib=../$seed_symlink
 else
-	time_command abyss-pe -C $abyss_dir v=-v k=$k name=$prefix np=$j  lib='pet' pet=$abyss_input long='longlib' longlib=../$seed_symlink B=$B H=4 kc=3
+	time_command abyss-pe -C $abyss_dir v=-v k=$k name=$prefix np=`echo $j | awk '{print ($1 > 1 ? $1 / 2 : $1)}'`  lib='pet' pet=$abyss_input long='longlib' longlib=../$seed_symlink
 fi
 abyss_fa=$abyss_dir/$prefix-10.fa
 


### PR DESCRIPTION
The use of OpenMPI by parts of ABySS requires specifying the number of physical CPU cores to use.
However, there's no such requirement for the rest of the tools used in the pipeline (biobloom).
On the assumption that the number of physical cores on the machine is half that of physical cores + hyperthreads, simply divide the -j parameter when passing it to abyss-pe.

This is tested on linux only and on a small personal machine and may or may not be appropriate for other configurations.
Perhaps it would be simpler to provide yet another option to kollector.sh (and kollector_multiple.sh) for setting ABySS jobs separately.