### PR TITLE
Bugfix: biobloomcategorizer needs the filter name for the -d option

### DIFF
--- a/bin/kollector-recruit.mk
+++ b/bin/kollector-recruit.mk
@@ -57,7 +57,7 @@ endif
 # iteratively add PETs with paired matches to Bloom filter
 $(name)_BBT.bf: $(seed).fai  $(pe1) $(pe2)
 	biobloommaker -i -k $k -p $(name)_BBT -f $(max_fpr) -t $j -n $n -r $r $(if $(subtract),-s $(subtract))  $(seed) <(zcat -f -- < $(pe1)) <(zcat -f -- < $(pe2))
-		
+
 #filter PET reads with built BF
 $(name).recruited_pe.fastq: $(name)_BBT.bf $(pe1) $(pe2)
-	biobloomcategorizer -p $(name)_BBT -t $j -d -f $(name)_BBT.bf -s $s -e -i <(zcat -f -- < $(pe1)) <(zcat -f -- < $(pe2)) >> $@	
+	biobloomcategorizer -p $(name)_BBT -t $j -d $(name)_BBT -f $(name)_BBT.bf -s $s -e -i <(zcat -f -- < $(pe1)) <(zcat -f -- < $(pe2)) >> $@


### PR DESCRIPTION
In `kollector-recruit.mk` the `biobloomcategorizer` command is lacking the filter name for the `-d` option. Perhaps this was added later to BioBloomTools, but it is required -- that stage of Kollector won't run without it.